### PR TITLE
Revert "msm: mdss: Avoid GPIO warnings during boot up"

### DIFF
--- a/drivers/video/msm/mdss/dsi_host_v2.c
+++ b/drivers/video/msm/mdss/dsi_host_v2.c
@@ -1311,13 +1311,6 @@ static int msm_dsi_cont_on(struct mdss_panel_data *pdata)
 		mutex_unlock(&ctrl_pdata->mutex);
 		return ret;
 	}
-	pinfo->panel_power_on = 1;
-	ret = mdss_dsi_panel_reset(pdata, 1);
-	if (ret) {
-		pr_err("%s: Panel reset failed\n", __func__);
-		mutex_unlock(&ctrl_pdata->mutex);
-		return ret;
-	}
 
 	msm_dsi_ahb_ctrl(1);
 	msm_dsi_prepare_clocks();

--- a/drivers/video/msm/mdss/dsi_v2.c
+++ b/drivers/video/msm/mdss/dsi_v2.c
@@ -100,7 +100,6 @@ static int dsi_panel_handler(struct mdss_panel_data *pdata, int enable)
 				dsi_ctrl_gpio_request(ctrl_pdata);
 			mdss_dsi_panel_reset(pdata, 1);
 		}
-		pdata->panel_info.panel_power_on = 1;
 		if (!pdata->panel_info.dynamic_switch_pending) {
 			rc = ctrl_pdata->on(pdata);
 			if (rc)
@@ -130,7 +129,6 @@ static int dsi_panel_handler(struct mdss_panel_data *pdata, int enable)
 		}
 		if (!pdata->panel_info.dynamic_switch_pending)
 			rc = ctrl_pdata->off(pdata);
-		pdata->panel_info.panel_power_on = 0;
 		if (!pdata->panel_info.dynamic_switch_pending) {
 			if (pdata->panel_info.type == MIPI_CMD_PANEL)
 				dsi_ctrl_gpio_free(ctrl_pdata);

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -75,7 +75,7 @@ static int mdss_dsi_panel_power_on(struct mdss_panel_data *pdata, int enable)
 			goto error;
 		}
 
-		if (!pdata->panel_info.mipi.lp11_init) {
+		if (pdata->panel_info.panel_power_on == 0 || !pdata->panel_info.mipi.lp11_init) {
 			ret = mdss_dsi_panel_reset(pdata, 1);
 			if (ret) {
 				pr_err("%s: Panel reset failed. rc=%d\n",

--- a/drivers/video/msm/mdss/mdss_dsi.h
+++ b/drivers/video/msm/mdss/mdss_dsi.h
@@ -273,7 +273,10 @@ struct mdss_dsi_ctrl_pdata {
 	int disp_en_gpio;
 	int disp_te_gpio;
 	int mode_gpio;
+	int rst_gpio_requested;
+	int disp_en_gpio_requested;
 	int disp_te_gpio_requested;
+	int mode_gpio_requested;
 	int bklt_ctrl;	/* backlight ctrl */
 	int pwm_period;
 	int pwm_pmic_gpio;


### PR DESCRIPTION
Fixed auo panel

This reverts commit 893941fab64e29fde9d1c82aa45eca64835cb073.

Change-Id: Ibb4c59307b4a685c17a8c8383aec2f88631aa62c
Signed-off-by: onano mohit.srivastava@openmailbox.org
