### PR TITLE
input: ft5x06_ts: Fix unbalanced IRQ warning

### DIFF
--- a/drivers/input/touchscreen/ft5x06_ts.c
+++ b/drivers/input/touchscreen/ft5x06_ts.c
@@ -966,17 +966,21 @@ static int fb_notifier_callback(struct notifier_block *self,
 {
 	struct fb_event *evdata = data;
 	int *blank;
+	static int u_blank;
 	struct ft5x06_data *ft5x06 =
 		container_of(self, struct ft5x06_data, fb_notif);
-		
+
 	if (evdata && evdata->data && event == FB_EVENT_BLANK &&
-			ft5x06 && ft5x06->dev) {		
+			ft5x06 && ft5x06->dev) {
 		blank = evdata->data;
 		if (*blank == FB_BLANK_UNBLANK) {
-			pr_info("ft5x06 resume!\n");
-			ft5x06_resume(ft5x06);
+			if(u_blank) {
+				pr_info("ft5x06 resume!\n");
+				ft5x06_resume(ft5x06);
+			}
 		}
 		else if (*blank == FB_BLANK_POWERDOWN) {
+			u_blank = 1;
 			pr_info("ft5x06 suspend!\n");
 			ft5x06_suspend(ft5x06);
 		}


### PR DESCRIPTION
[    7.144144] ------------[ cut here ]------------
[    7.144161] WARNING: at /home/onano/cm/kernel/xiaomi/armani/kernel/irq/manage.c:428 enable_irq+0x40/0x88()
[    7.144163] Unbalanced enable for IRQ 335
[    7.144180] [<c011142c>](unwind_backtrace+0x0/0x160) from [<c01bf83c>](warn_slowpath_fmt+0x60/0x90)
[    7.144190] [<c01bf83c>](warn_slowpath_fmt+0x60/0x90) from [<c02350e0>](enable_irq+0x40/0x88)
[    7.144200] [<c02350e0>](enable_irq+0x40/0x88) from [<c06b5060>](ft5x06_resume+0x68/0x7c)
[    7.144208] [<c06b5060>](ft5x06_resume+0x68/0x7c) from [<c06b510c>](fb_notifier_callback+0x98/0xa4)
[    7.144216] [<c06b510c>](fb_notifier_callback+0x98/0xa4) from [<c01eac5c>](notifier_call_chain+0x78/0xb0)
[    7.144224] [<c01eac5c>](notifier_call_chain+0x78/0xb0) from [<c01eb0e4>](__blocking_notifier_call_chain+0x50/0x74)
[    7.144231] [<c01eb0e4>](__blocking_notifier_call_chain+0x50/0x74) from [<c01eb120>](blocking_notifier_call_chain+0x18/0x20)
[    7.144239] [<c01eb120>](blocking_notifier_call_chain+0x18/0x20) from [<c0481b0c>](fb_blank+0x5c/0x78)
[    7.144246] [<c0481b0c>](fb_blank+0x5c/0x78) from [<c0481e70>](do_fb_ioctl+0x348/0x5fc)
[    7.144254] [<c0481e70>](do_fb_ioctl+0x348/0x5fc) from [<c02c6768>](do_vfs_ioctl+0x3e0/0x5a4)
[    7.144263] [<c02c6768>](do_vfs_ioctl+0x3e0/0x5a4) from [<c02c69b4>](sys_ioctl+0x88/0x98)
[    7.144271] [<c02c69b4>](sys_ioctl+0x88/0x98) from [<c0109fc0>](ret_fast_syscall+0x0/0x30)
[    7.144274] ---[ end trace 684f3453e9249791 ]---

thewisenerd pointed out that unbalanced IRQ was happening due to no check
if driver was already in resume or not

Fix : add proper checks before resume

Change-Id: I949c84bd80bb230b571e4c8429c8ac4bae5c3c60
Signed-off-by: onano mohit.srivastava@openmailbox.org
