### PR TITLE
Moar Warning Fixes

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -699,7 +699,6 @@ int mdss_dsi_on(struct mdss_panel_data *pdata)
 		pdata->panel_info.panel_power_on = 0;
 		return ret;
 	}
-	pdata->panel_info.panel_power_on = 1;
 
 	mdss_dsi_phy_sw_reset((ctrl_pdata->ctrl_base));
 	mdss_dsi_phy_init(pdata);
@@ -718,6 +717,7 @@ int mdss_dsi_on(struct mdss_panel_data *pdata)
 	if (mipi->lp11_init)
 		mdss_dsi_panel_reset(pdata, 1);
 
+	pdata->panel_info.panel_power_on = 1;
 	if (mipi->init_delay)
 		usleep(mipi->init_delay);
 

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -75,7 +75,7 @@ static int mdss_dsi_panel_power_on(struct mdss_panel_data *pdata, int enable)
 			goto error;
 		}
 
-		if (pdata->panel_info.panel_power_on == 0 || !pdata->panel_info.mipi.lp11_init) {
+		if (!pdata->panel_info.mipi.lp11_init) {
 			ret = mdss_dsi_panel_reset(pdata, 1);
 			if (ret) {
 				pr_err("%s: Panel reset failed. rc=%d\n",


### PR DESCRIPTION
previous commit for fixing auo panel introduced a new warning
on resume

[ 1824.576423] gpio_request: gpio-25 (disp_rst_n) status -16
[ 1824.576427] request reset gpio failed, rc=-16
[ 1824.576429] gpio request failed
[ 1824.737647] ft5x06 resume!

Fix auo panel and fix this warning by respecting mipi->init_delay
and be close to CAF conditions and respecting their mdss changes
