### PR TITLE
input: ft5x06_ts: unregister notifier_block on remove()

### DIFF
--- a/drivers/input/touchscreen/ft5x06_ts.c
+++ b/drivers/input/touchscreen/ft5x06_ts.c
@@ -2049,10 +2049,16 @@ EXPORT_SYMBOL_GPL(ft5x06_probe);
 void ft5x06_remove(struct ft5x06_data *ft5x06)
 {
 	struct ft5x06_ts_platform_data *pdata = ft5x06->dev->platform_data;
-
+#if defined(CONFIG_FB)
+	int error;
+#endif
 	cancel_delayed_work_sync(&ft5x06->noise_filter_delayed_work);
 	unregister_power_supply_notifier(&ft5x06->power_supply_notifier);
-#ifdef CONFIG_HAS_EARLYSUSPEND
+#if defined(CONFIG_FB)
+	error = fb_unregister_client(&ft5x06->fb_notif);
+	if (error)
+		dev_err(ft5x06->dev, "Error occurred while unregistering fb_notifier.\n");
+#elif defined(CONFIG_HAS_EARLYSUSPEND)
 	unregister_early_suspend(&ft5x06->early_suspend);
 #endif
 	sysfs_remove_group(&ft5x06->dev->kobj, &ft5x06_attr_group);


### PR DESCRIPTION
commit https://github.com/armani-dev/kernel_test/commit/9284dc282520a1e9e1d8b404137d2b2ef18fbc8e
registers fb_notif but doesn't unregister on ft5x06_remove()
Fix That behaviour

Change-Id: I48fbaf602eb67812cd377c0541e2c9f8f69a5e9b
Signed-off-by: onano mohit.srivastava@openmailbox.org
